### PR TITLE
Fix linewidth arg type

### DIFF
--- a/src/main/java/com/github/sh0nk/matplotlib4j/builder/HistBuilderImpl.java
+++ b/src/main/java/com/github/sh0nk/matplotlib4j/builder/HistBuilderImpl.java
@@ -108,12 +108,12 @@ public class HistBuilderImpl implements HistBuilder {
     }
 
     @Override
-    public HistBuilder linewidth(String arg) {
+    public HistBuilder linewidth(double arg) {
         return patchBuilder.linewidth(arg);
     }
 
     @Override
-    public HistBuilder lw(String arg) {
+    public HistBuilder lw(double arg) {
         return patchBuilder.lw(arg);
     }
 

--- a/src/main/java/com/github/sh0nk/matplotlib4j/builder/PlotBuilderImpl.java
+++ b/src/main/java/com/github/sh0nk/matplotlib4j/builder/PlotBuilderImpl.java
@@ -44,12 +44,12 @@ public class PlotBuilderImpl implements PlotBuilder {
     }
 
     @Override
-    public PlotBuilder linewidth(String arg) {
+    public PlotBuilder linewidth(double arg) {
         return line2DBuilder.linewidth(arg);
     }
 
     @Override
-    public PlotBuilder lw(String arg) {
+    public PlotBuilder lw(double arg) {
         return line2DBuilder.lw(arg);
     }
 

--- a/src/main/java/com/github/sh0nk/matplotlib4j/kwargs/Line2DBuilder.java
+++ b/src/main/java/com/github/sh0nk/matplotlib4j/kwargs/Line2DBuilder.java
@@ -8,9 +8,9 @@ public interface Line2DBuilder<T extends Builder> extends KwargsBuilder {
 
     T ls(String arg);
 
-    T linewidth(String arg);
+    T linewidth(double arg);
 
-    T lw(String arg);
+    T lw(double arg);
 
     T label(String arg);
 

--- a/src/main/java/com/github/sh0nk/matplotlib4j/kwargs/Line2DBuilderImpl.java
+++ b/src/main/java/com/github/sh0nk/matplotlib4j/kwargs/Line2DBuilderImpl.java
@@ -23,12 +23,12 @@ public class Line2DBuilderImpl<T extends Builder> implements Line2DBuilder<T> {
     }
 
     @Override
-    public T linewidth(String arg) {
+    public T linewidth(double arg) {
         return lw(arg);
     }
 
     @Override
-    public T lw(String arg) {
+    public T lw(double arg) {
         return innerBuilder.addToKwargs("lw", arg);
     }
 

--- a/src/main/java/com/github/sh0nk/matplotlib4j/kwargs/PatchBuilder.java
+++ b/src/main/java/com/github/sh0nk/matplotlib4j/kwargs/PatchBuilder.java
@@ -8,9 +8,9 @@ public interface PatchBuilder<T extends Builder> extends KwargsBuilder {
 
     T ls(String arg);
 
-    T linewidth(String arg);
+    T linewidth(double arg);
 
-    T lw(String arg);
+    T lw(double arg);
 
     T label(String arg);
 

--- a/src/main/java/com/github/sh0nk/matplotlib4j/kwargs/PatchBuilderImpl.java
+++ b/src/main/java/com/github/sh0nk/matplotlib4j/kwargs/PatchBuilderImpl.java
@@ -23,12 +23,12 @@ public class PatchBuilderImpl<T extends Builder> implements PatchBuilder<T> {
     }
 
     @Override
-    public T linewidth(String arg) {
+    public T linewidth(double arg) {
         return lw(arg);
     }
 
     @Override
-    public T lw(String arg) {
+    public T lw(double arg) {
         return innerBuilder.addToKwargs("lw", arg);
     }
 

--- a/src/test/java/com/github/sh0nk/matplotlib4j/MainTest.java
+++ b/src/test/java/com/github/sh0nk/matplotlib4j/MainTest.java
@@ -47,7 +47,8 @@ public class MainTest {
         plt.plot()
            .add(Arrays.asList(1.3, 20, 200, 300, 400, 1000), Arrays.asList(1, 4, 10, 20, 100, 800))
            .label("label")
-           .linestyle("--");
+           .linestyle("--")
+           .linewidth(2.0);
         plt.xscale(ScaleBuilder.Scale.log);
         plt.yscale(ScaleBuilder.Scale.log);
         plt.xlabel("xlabel");


### PR DESCRIPTION
`linewidth` cannot be string.

```
DEBUG - .plot command: ret_dd16cd73_9c59_476d_887e_4025d5466894 = plt.plot(np.array([1.3, 2]),ls="--",label="label",lw="2.0")
DEBUG - .plot command: ret_ac691ba4_5cb2_4009_b496_cde497e62340 = plt.xlabel("xlabel")
DEBUG - .plot command: ret_e3324406_a4d7_4285_9186_e43af8d71fb7 = plt.ylabel("ylabel")
DEBUG - .plot command: ret_a917f792_a29e_4165_a576_17ef7be0d64d = plt.text(0.5,0.2,"text")
DEBUG - .plot command: plt.title("Title!")
DEBUG - .plot command: ret_01f03ee8_6fd0_4d3d_8443_439f53abb8dc = plt.legend()
DEBUG - Commands... : [python, /var/folders/cg/kzktgn7x25sfh5l9_rd22p5w0000gn/T/1616729556083-0/exec.py]
ERROR - Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/matplotlib/artist.py", line 55, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/matplotlib/figure.py", line 1034, in draw
    func(*args)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/matplotlib/artist.py", line 55, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/matplotlib/axes.py", line 2086, in draw
    a.draw(renderer)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/matplotlib/artist.py", line 55, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/matplotlib/lines.py", line 534, in draw
    gc.set_linewidth(self._linewidth)
TypeError: a float is required
```
